### PR TITLE
Loading datafiles without timearray inside data file

### DIFF
--- a/pyTST/core.py
+++ b/pyTST/core.py
@@ -82,11 +82,12 @@ class pyTST:
             usecols = (signal_column, time_column)
 
         timedata = np.loadtxt(filename, usecols=usecols, **kwargs)
-        self.signal_array = timedata[:, 0]
-
+        
         if time_column is None:
+            self.signal_array = timedata
             self.time_array = (np.array(range(len(self.signal_array)))+1)*tstep
         else:
+            self.signal_array = timedata[:, 0]
             self.time_array = timedata[:, 1]*tstep
 
 


### PR DESCRIPTION
Hey, this is a necessary fix when you load a datafile without an array for the time indices (without it it crashes)